### PR TITLE
Compile `format_args!` to a closure instead of list of pieces.

### DIFF
--- a/core/src/format.rs
+++ b/core/src/format.rs
@@ -54,6 +54,7 @@ macro_rules! format {
 ///     "Hello, <span style=color:green>world</span>!"
 /// );
 /// ```
+#[inline]
 pub fn format(args: Arguments<'_>) -> String {
     let mut output = String::new();
     output

--- a/core/src/formatter.rs
+++ b/core/src/formatter.rs
@@ -48,6 +48,7 @@ pub struct Formatter<'a> {
 }
 
 impl core::fmt::Debug for Formatter<'_> {
+    #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result {
         f.debug_struct("Formatter")
             .field("style", &self.style)
@@ -57,6 +58,7 @@ impl core::fmt::Debug for Formatter<'_> {
 }
 
 impl<'a> Formatter<'a> {
+    #[inline]
     pub(crate) fn new(write: &'a mut (dyn Write + 'a)) -> Self {
         Self {
             style: Style::default(),
@@ -99,11 +101,17 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    pub(crate) fn with_args<'b>(&'b mut self, format: &FormatterArgs<'b>) -> Formatter<'b> {
+    #[doc(hidden)]
+    /// pub for macros
+    pub fn with_args<'b>(
+        &'b mut self,
+        format: &FormatterArgs<'b>,
+        restyle: impl Restyle,
+    ) -> Formatter<'b> {
         Formatter {
             write: &mut *self.write,
             format: *format,
-            style: self.style,
+            style: self.style.with(restyle),
         }
     }
 
@@ -130,6 +138,7 @@ impl<'a> Formatter<'a> {
     ///     "Hello <span style=color:red>Ferris</span> and <span style=color:cyan>Gorris</span>"
     /// );
     /// ```
+    #[inline]
     pub fn write_str(&mut self, s: &str) -> Result {
         self.write.write_str(s, self.style)?;
         Ok(())
@@ -157,6 +166,7 @@ impl<'a> Formatter<'a> {
     ///     "Hello <span style=color:red>Ferris</span> and <span style=color:cyan>Gorris</span>"
     /// );
     /// ```
+    #[inline]
     pub fn write_fmt(&mut self, args: Arguments<'_>) -> Result {
         args.fmt(self)?;
         Ok(())
@@ -164,16 +174,19 @@ impl<'a> Formatter<'a> {
 }
 
 impl<'a> Write for Formatter<'a> {
+    #[inline]
     fn write_str(&mut self, s: &str, style: Style) -> Result {
         self.with(style).write_str(s)
     }
 
+    #[inline]
     fn write_fmt(&mut self, args: Arguments<'_>) -> Result {
         self.write_fmt(args)
     }
 }
 
 impl<'a> core::fmt::Write for Formatter<'a> {
+    #[inline]
     fn write_str(&mut self, s: &str) -> Result {
         self.write_str(s)
     }

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -214,6 +214,7 @@ pub trait Write {
     /// output.write_fmt(stylish::format_args!("{:(fg=red)}", '☎'))?;
     /// # Ok::<(), std::io::Error>(())
     /// ```
+    #[inline]
     fn write_fmt(&mut self, args: Arguments<'_>) -> Result<()> {
         let mut trap = ErrorTrap::new(self);
 
@@ -241,6 +242,7 @@ pub trait Write {
     /// )?;
     /// # Ok::<(), std::io::Error>(())
     /// ```
+    #[inline]
     fn by_ref(&mut self) -> &mut Self
     where
         Self: Sized,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -54,8 +54,8 @@ pub mod 𓀄 {
     pub use with_builtin_macros::with_builtin;
 
     pub use crate::{
-        arguments::{Argument, Arguments, FormatTrait, StdFmt},
-        formatter::{Align, DebugHex, FormatterArgs, Sign},
+        arguments::{Arguments, StdFmt, StdFmtDebug, StdFmtOther},
+        formatter::{Align, DebugHex, Formatter, FormatterArgs, Sign},
         Background, Color, Display, Foreground, Intensity, StyleDiff,
     };
 }

--- a/core/src/std_compat.rs
+++ b/core/src/std_compat.rs
@@ -55,36 +55,19 @@ macro_rules! std_write {
         })
     };
 
-    (@str $f:ident $val:ident [Display $($flag:ident)*]) => {
+    // For most traits we can pipe them through `Display` since they have the same function
+    // signature
+    (@str $f:ident $val:ident [Other $($flag:ident)*]) => {
         std_write!(@str $f $val [$($flag)*] { { debug_hex: _, } => (("",),); })
     };
+
+    // But `Debug` is special as it has extra hex flags
     (@str $f:ident $val:ident [Debug $($flag:ident)*]) => {
         std_write!(@str $f $val [$($flag)*] {
             { debug_hex: None, } => (("?",),);
             { debug_hex: Some(crate::formatter::DebugHex::Lower), } => (("x?",),);
             { debug_hex: Some(crate::formatter::DebugHex::Upper), } => (("X?",),);
         })
-    };
-    (@str $f:ident $val:ident [Octal $($flag:ident)*]) => {
-        std_write!(@str $f $val [$($flag)*] { { debug_hex: _, } => (("o",),); })
-    };
-    (@str $f:ident $val:ident [LowerHex $($flag:ident)*]) => {
-        std_write!(@str $f $val [$($flag)*] { { debug_hex: _, } => (("x",),); })
-    };
-    (@str $f:ident $val:ident [UpperHex $($flag:ident)*]) => {
-        std_write!(@str $f $val [$($flag)*] { { debug_hex: _, } => (("X",),); })
-    };
-    (@str $f:ident $val:ident [Pointer $($flag:ident)*]) => {
-        std_write!(@str $f $val [$($flag)*] { { debug_hex: _, } => (("p",),); })
-    };
-    (@str $f:ident $val:ident [Binary $($flag:ident)*]) => {
-        std_write!(@str $f $val [$($flag)*] { { debug_hex: _, } => (("b",),); })
-    };
-    (@str $f:ident $val:ident [LowerExp $($flag:ident)*]) => {
-        std_write!(@str $f $val [$($flag)*] { { debug_hex: _, } => (("e",),); })
-    };
-    (@str $f:ident $val:ident [UpperExp $($flag:ident)*]) => {
-        std_write!(@str $f $val [$($flag)*] { { debug_hex: _, } => (("E",),); })
     };
 
     ($f:ident, $trait:ident, $val:ident) => {

--- a/core/src/string.rs
+++ b/core/src/string.rs
@@ -51,12 +51,14 @@ impl String {
     /// ```rust
     /// assert_eq!(stylish::html::format!("{:s}", stylish::String::new()), "");
     /// ```
+    #[inline]
     pub fn new() -> Self {
         Self::default()
     }
 }
 
 impl Write for String {
+    #[inline]
     fn write_str(&mut self, s: &str, style: Style) -> Result {
         if Some(style) != self.styles.last().map(|&(_, style)| style) {
             self.styles.push((self.string.len(), style));
@@ -67,6 +69,7 @@ impl Write for String {
 }
 
 impl Display for String {
+    #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let mut styles = self.styles.iter().peekable();
         while let Some(&(start, style)) = styles.next() {

--- a/core/src/write.rs
+++ b/core/src/write.rs
@@ -64,6 +64,7 @@ pub trait Write {
     /// );
     /// # Ok::<(), core::fmt::Error>(())
     /// ```
+    #[inline]
     fn write_char(&mut self, c: char, style: Style) -> Result {
         self.write_str(c.encode_utf8(&mut [0; 4]), style)
     }
@@ -85,6 +86,7 @@ pub trait Write {
     /// assert_eq!(s, "<span style=color:red>☎</span>");
     /// # Ok::<(), core::fmt::Error>(())
     /// ```
+    #[inline]
     fn write_fmt(mut self: &mut Self, args: Arguments<'_>) -> Result {
         Formatter::new(&mut self).write_fmt(args)
     }

--- a/plain/src/format.rs
+++ b/plain/src/format.rs
@@ -33,6 +33,7 @@ macro_rules! format {
 ///     "Hello Ferris",
 /// );
 /// ```
+#[inline]
 pub fn format(args: Arguments<'_>) -> String {
     let mut output = Plain::new(String::new());
     output

--- a/style/src/lib.rs
+++ b/style/src/lib.rs
@@ -129,12 +129,14 @@ pub trait Restyle {
 }
 
 impl Default for Color {
+    #[inline]
     fn default() -> Self {
         Self::Default
     }
 }
 
 impl Default for Intensity {
+    #[inline]
     fn default() -> Self {
         Self::Normal
     }
@@ -178,6 +180,7 @@ impl Style {
     ///     }
     /// ));
     /// ```
+    #[inline]
     pub fn diff_from(self, original: Style) -> StyleDiff {
         fn diff<T: PartialEq>(original: T, new: T) -> Option<T> {
             if original == new {
@@ -224,6 +227,7 @@ impl<T: Restyle> Restyle for Option<T> {
 }
 
 impl Restyle for StyleDiff {
+    #[inline]
     fn apply(&self, style: Style) -> Style {
         (
             self.foreground.map(Foreground),
@@ -235,12 +239,14 @@ impl Restyle for StyleDiff {
 }
 
 impl Restyle for Style {
+    #[inline]
     fn apply(&self, _style: Style) -> Style {
         *self
     }
 }
 
 impl Restyle for Foreground {
+    #[inline]
     fn apply(&self, style: Style) -> Style {
         let &Foreground(foreground) = self;
         Style {
@@ -251,6 +257,7 @@ impl Restyle for Foreground {
 }
 
 impl Restyle for Background {
+    #[inline]
     fn apply(&self, style: Style) -> Style {
         let &Background(background) = self;
         Style {
@@ -261,6 +268,7 @@ impl Restyle for Background {
 }
 
 impl Restyle for Intensity {
+    #[inline]
     fn apply(&self, style: Style) -> Style {
         Style {
             intensity: *self,
@@ -270,6 +278,7 @@ impl Restyle for Intensity {
 }
 
 impl Restyle for () {
+    #[inline]
     fn apply(&self, style: Style) -> Style {
         style
     }


### PR DESCRIPTION
Gives an ~-27% runtime change on a pretty basic benchmark in `cbor-diag`.