### PR TITLE
Avoid change in float rounding behaviour in tests

### DIFF
--- a/tests/std/float.rs
+++ b/tests/std/float.rs
@@ -9,7 +9,7 @@ fn test_format_f64() {
     assert_eq!("10", format!("{:.0}", 9.9f64));
     assert_eq!("9.8", format!("{:.1}", 9.849f64));
     assert_eq!("9.9", format!("{:.1}", 9.851f64));
-    assert_eq!("1", format!("{:.0}", 0.5f64));
+    assert_eq!("2", format!("{:.0}", 1.5f64));
     assert_eq!("1.23456789e6", format!("{:e}", 1234567.89f64));
     assert_eq!("1.23456789e3", format!("{:e}", 1234.56789f64));
     assert_eq!("1.23456789E6", format!("{:E}", 1234567.89f64));
@@ -25,7 +25,7 @@ fn test_format_f32() {
     assert_eq!("10", format!("{:.0}", 9.9f32));
     assert_eq!("9.8", format!("{:.1}", 9.849f32));
     assert_eq!("9.9", format!("{:.1}", 9.851f32));
-    assert_eq!("1", format!("{:.0}", 0.5f32));
+    assert_eq!("2", format!("{:.0}", 1.5f32));
     assert_eq!("1.2345679e6", format!("{:e}", 1234567.89f32));
     assert_eq!("1.2345679e3", format!("{:e}", 1234.56789f32));
     assert_eq!("1.2345679E6", format!("{:E}", 1234567.89f32));


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/102935 changed the behaviour of `format!("{:.0}", 0.5)` to round to 0 instead of 1 for consistency. The test case I copied from `std` was using this, so change to using 1.5 which has the same behaviour on stable and nightly.